### PR TITLE
Added support for Oracle Linux running Unbreakable Enterprise Kernel …

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Plugin for NRPE (Nagios Remote Plugin Executor) for Debian/Ubuntu to check
 when APT was able to update the software database last time
 
 #### check_reboot-required
-Plugin for NRPE (Nagios Remote Plugin Executor) for Debian/Ubuntu and Red Hat/CentOS
+Plugin for NRPE (Nagios Remote Plugin Executor) for Debian/Ubuntu and Red Hat/CentOS/Oracle Linux
 to check if a reboot are required and also list packages that requires reboot
 
 #### check_salt-minion

--- a/check_reboot-required/check_reboot-required
+++ b/check_reboot-required/check_reboot-required
@@ -107,7 +107,9 @@ EOF
 function distro_name() {
 	if [[ -e /etc/redhat-release ]]; then
 		REDHAT_RELEASE=`cat /etc/redhat-release`
-		if [[ `cat /etc/redhat-release | grep CentOS` != "" ]]; then
+		if [[ -e /etc/oracle-release && `uname -r` == *"uek"* ]]; then
+			echo "Oracle UEK"
+		elif [[ `cat /etc/redhat-release | grep CentOS` != "" ]]; then
 			echo "CentOS"
 		elif [[ `cat /etc/redhat-release | grep "Red Hat"` != "" ]]; then
 			echo "Red Hat"
@@ -165,7 +167,11 @@ function CheckDebianRebootRequired() {
 	fi
 }
 function CheckRedHatRebootRequired() {
-	LAST_KERNEL=`/bin/rpm -q --last kernel | /usr/bin/head -1 | /usr/bin/perl -pe 's/^kernel-(\S+).*/$1/'`
+	if  [[ `distro_name` == "Oracle UEK" ]]; then
+		LAST_KERNEL=`/bin/rpm -q --last kernel-uek | /usr/bin/head -1 | /usr/bin/perl -pe 's/^kernel-uek-(\S+).*/$1/'`
+	else
+		LAST_KERNEL=`/bin/rpm -q --last kernel | /usr/bin/head -1 | /usr/bin/perl -pe 's/^kernel-(\S+).*/$1/'`
+	fi
 	RUNNING_KERNEL=`uname -r`
 
 	if [[ $LAST_KERNEL != $RUNNING_KERNEL ]];	then
@@ -247,7 +253,7 @@ case `distro_name` in
 	"Debian"|"Ubuntu")
 		CheckDebianRebootRequired
 	;;
-	"Red Hat"|"CentOS")
+	"Red Hat"|"CentOS"|"Oracle UEK")
 		CheckRedHatRebootRequired
 	;;
 	*)


### PR DESCRIPTION
This will identify and handle Oracle Linux RHEL variant running the Unbreakable Enterprise Kernel. Oracle Linux may run the stock RHEL kernel as well, so the check is specific to the UEK.